### PR TITLE
startSession is now marked as throws

### DIFF
--- a/SamplePaymentSDK/SamplePaymentSDK/UI Resources/PaymentViewController.swift
+++ b/SamplePaymentSDK/SamplePaymentSDK/UI Resources/PaymentViewController.swift
@@ -72,7 +72,7 @@ class PaymentViewController: UIViewController, SDKOverlayWindowPresentable {
         swipeControl.delegate = self
 
         // Once the view is configured and prepared to present, start the Moonsense SDK Session
-        session = Moonsense.startSession(duration: Constants.sessionDuration, labels: [Constants.paymentSessionLabel])
+        session = try? Moonsense.startSession(duration: Constants.sessionDuration, labels: [Constants.paymentSessionLabel])
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Description

With the release of `0.1.0-alpha3` the `Moonsense.startSession()` method is marked as `throws`. We now need to perform a `try` before starting the session.
