### PR TITLE
Fixed bad CURL link

### DIFF
--- a/SampleCoreApp/README.md
+++ b/SampleCoreApp/README.md
@@ -12,7 +12,7 @@ The `SampleCoreApp` project demonstrates the use of the Moonsense iOS Core SDK w
 
 At this time, the `MoonsenseCoreSDK.xcframework.zip`, `MoonsenseCoreSDK-static.xcframework.zip` and `MoonsenseCoreSDK.doccarchive.zip` artifacts must be manually integrated into your project. You can download the latest versions from the following links:
 
-* [`MoonsenseCoreSDK.xcframework.zip`](https://dl.moonsense.io/basic/sdk/raw/names/MoonsenseCoreSDK.xcframework/versions/1.0.0/MoonsenseSDK.xcframework-1.0.0.zip)
+* [`MoonsenseCoreSDK.xcframework.zip`](https://dl.moonsense.io/basic/sdk/raw/names/MoonsenseCoreSDK.xcframework/versions/1.0.0/MoonsenseCoreSDK.xcframework-1.0.0.zip)
 * [`MoonsenseCoreSDK-static.xcframework.zip`](https://dl.moonsense.io/basic/sdk/raw/names/MoonsenseCoreSDK-static.xcframework/versions/1.0.0/MoonsenseCoreSDK-static.xcframework-1.0.0.zip)
 * [`MoonsenseCoreSDK.doccarchive.zip`](https://dl.moonsense.io/basic/sdk/raw/names/MoonsenseCoreSDK.doccarchive/versions/1.0.0/MoonsenseCoreSDK.doccarchive-1.0.0.zip)
 
@@ -21,7 +21,7 @@ Once downloaded, unzip the files and drop the expanded files into your project.
 *Note:* The downloads require the authorization token as outlined in the main [`README.md`](../README.md/#configuring-netrc-for-authorizing-downloads). For best results download the artifacts using `curl` with the `-n` option. For example:
 
 ```
-curl -n -o MoonsenseSDK.xcframework.zip https://dl.moonsense.io/basic/sdk/raw/names/MoonsenseSDK.xcframework/versions/1.0.0/MoonsenseSDK.xcframework-1.0.0.zip
+curl -n -o MoonsenseCoreSDK.xcframework.zip https://dl.moonsense.io/basic/sdk/raw/names/MoonsenseCoreSDK.xcframework/versions/1.0.0/MoonsenseCoreSDK.xcframework-1.0.0.zip
 ```
 
 ## Terms Of Service


### PR DESCRIPTION
## Description

The SampleCoreApp's Readme file had a copy/paste issue where the CURL command was showing the Cloud SDK, not the CoreSDK.

## Breakdown

- Updated the `SampleCoreApp/README.md` file with the correct links.
- Also updated the "source of truth" version of this file so that it will be correctly published on the next SDK release as well.

## Validation

- Manually tested and validated all links in the README to ensure they are downloading the proper files.

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]
